### PR TITLE
Rework results reporting to backend

### DIFF
--- a/expcore/Mini_games.lua
+++ b/expcore/Mini_games.lua
@@ -416,7 +416,7 @@ local function start_from_lobby(name, player_count, args)
     end
 
     local data = {
-        type         = 'Start_game',
+        type         = 'start_game',
         player_count = player_count,
         args         = args,
         name         = name,
@@ -424,7 +424,7 @@ local function start_from_lobby(name, player_count, args)
     }
 
     dlog('Start lobby:', name, ' Address:', server_address)
-    game.write_file('mini_games/starting_game', game.table_to_json(data), false)
+    game.write_file('mini_games/start_game', game.table_to_json(data), false)
 end
 
 --- Start a mini game from this server, calls on_participant_joined then on_start
@@ -463,13 +463,13 @@ local start_game = Token.register(function(timeout_nonce)
 
     -- Write the game start to file
     local data = {
-        type      = 'Started_game',
+        type      = 'started_game',
         players   = Mini_games.get_participant_names(),
         name      = mini_game.name,
     }
 
     dlog('Start:', mini_game.name, 'Player Count:', #data.players)
-    game.write_file('mini_games/starting_game', game.table_to_json(data), false)
+    game.write_file('mini_games/started__game', game.table_to_json(data), false)
     primitives.state = 'Started'
     dlog('===== State Change =====')
 end)
@@ -660,7 +660,7 @@ end
 --- Format an array to be the correct format for airtable
 function Mini_games.format_airtable(args)
     local data = {
-        type="end_game",
+        type="stopped_game",
         Gold=args[1],
         Gold_data=args[2],
         Silver=args[3],
@@ -709,7 +709,7 @@ function Mini_games.stop_game()
         dlog('Call: On Stop')
         local success, res = xpcall(on_stop, internal_error)
         if success and res then
-            game.write_file('mini_games/end_game', res, false)
+            game.write_file('mini_games/stopped_game', res, false)
         end
     end
 

--- a/expcore/Mini_games.lua
+++ b/expcore/Mini_games.lua
@@ -424,7 +424,7 @@ local function start_from_lobby(name, player_count, args)
     }
 
     dlog('Start lobby:', name, ' Address:', server_address)
-    game.write_file('mini_games/start_game', game.table_to_json(data), false)
+    game.write_file('mini_games/start_game', game.table_to_json(data), false, 0)
 end
 
 --- Start a mini game from this server, calls on_participant_joined then on_start
@@ -469,7 +469,7 @@ local start_game = Token.register(function(timeout_nonce)
     }
 
     dlog('Start:', mini_game.name, 'Player Count:', #data.players)
-    game.write_file('mini_games/started__game', game.table_to_json(data), false)
+    game.write_file('mini_games/started_game', game.table_to_json(data), false, 0)
     primitives.state = 'Started'
     dlog('===== State Change =====')
 end)
@@ -709,7 +709,7 @@ function Mini_games.stop_game()
         dlog('Call: On Stop')
         local success, res = xpcall(on_stop, internal_error)
         if success and res then
-            game.write_file('mini_games/stopped_game', res, false)
+            game.write_file('mini_games/stopped_game', res, false, 0)
         end
     end
 

--- a/modules/mini-games/Race.lua
+++ b/modules/mini-games/Race.lua
@@ -252,20 +252,28 @@ local colors =  {
 --- Function called by mini game module to stop a race
 local function stop()
     -- Print the place that each player came
-    local airtable = {}
+    local results = {}
     for name, value in pairs(scores["finish_times"]) do
         local time = value[2]
         local place = Nth(value[1])
         local colour = colors[place] or colors.default
-        if colour ~= colors.default then
-            local index = value[1] * 2
-            airtable[index-1] = name
-            airtable[index] = math.round(time,2)
+
+        local up_result = results[#results]
+        if up_result and up_result.score == math.round(time, 2) then
+            up_result.players[#up_result.players + 1] = name
+
+        else
+            results[#results + 1] = {
+                place = value[1],
+                score = math.round(time, 2),
+                players = {name}
+            }
         end
+
         game.print(message_format:format(place, name, time), colour)
     end
 
-    return Mini_games.format_airtable(airtable)
+    return results
 end
 
 --- The last function to be called in order to clean up variables

--- a/modules/mini-games/space_race/scenario.lua
+++ b/modules/mini-games/space_race/scenario.lua
@@ -349,7 +349,7 @@ local function stop()
         end
     end
 
-    return Mini_games.format_airtable{primitives.won, player_names}
+    return {{ place = 1, score = 1, players = player_names }}
 end
 
 --- Used to stop a game and reset all variables, called by mini game manager

--- a/modules/mini-games/tightspot.lua
+++ b/modules/mini-games/tightspot.lua
@@ -383,21 +383,29 @@ local function stop()
     end)
 
     -- Print the player scores
-    local airtable = {}
+    local results = {}
     for i, score in ipairs(scores) do
         local money = score[1]
         local player_name = score[2]
         local place = Nth(i)
 
-        local index = i*2
-        airtable[index-1] = score[2]
-        airtable[index] = math.round(money,2)
+        local up_result = results[#results]
+        if up_result and up_result.score == math.round(money, 2) then
+            up_result.players[#up_result.players + 1] = player_name
+
+        else
+            results[#results + 1] = {
+                place = i,
+                players = {player_name},
+                score = math.round(money, 2)
+            }
+        end
 
         local colour = colors[place] or colors.default
         game.print(message_format:format(place, player_name, money), colour)
     end
 
-    return Mini_games.format_airtable(airtable)
+    return results
 end
 
 --- The last function to be called, used to clean up variables


### PR DESCRIPTION
Change reporting of player placement to backend to be an array of result records each containing the place, score and players on it in order to support team placement and ties.