### PR TITLE
General Fixes

### DIFF
--- a/expcore/Mini_games.lua
+++ b/expcore/Mini_games.lua
@@ -218,15 +218,16 @@ end
 function Mini_games.respawn_spectator(player)
     Gui.update_top_flow(player)
     if player.character then player.character.destroy() end
+    player.set_controller{ type = defines.controllers.god }
     if primitives.state == 'Closing' or primitives.state == 'Loading' then
         dlog('Respawn in lobby:', player.name)
         local surface = game.surfaces.nauvis
         local pos = surface.find_non_colliding_position('character', {-35, 55}, 6, 1)
-        player.create_character()
         player.teleport(pos, surface)
+        player.create_character()
     elseif primitives.current_game then
         dlog('Respawn in spectator:', player.name)
-        player.set_controller{ type = defines.controllers.god }
+        player.set_controller{ type = defines.controllers.spectator }
     end
 end
 

--- a/expcore/Mini_games.lua
+++ b/expcore/Mini_games.lua
@@ -62,7 +62,7 @@ local function internal_error(error_message)
 end
 
 --- Used to debug mini game control flow
-local DEBUG = true
+local DEBUG = false
 local function dlog(...)
     if not DEBUG then return end
     log{'mini-game-log', primitives.current_game or 'None', primitives.state, table.concat({...}, ' ')}

--- a/expcore/commands.lua
+++ b/expcore/commands.lua
@@ -676,6 +676,7 @@ return Commands.error('The player you selected is offline')
 ]]
 function Commands.error(error_message, play_sound)
     error_message = error_message or ''
+    if type(error_message) == 'string' then error_message = error_message:gsub('%.%.%..-/temp/currently%-playing', '') end
     player_return({'expcore-commands.command-fail', error_message}, 'orange_red')
     if play_sound ~= false then
         play_sound = play_sound or 'utility/wire_pickup'

--- a/modules/gui/mini_game_loading.lua
+++ b/modules/gui/mini_game_loading.lua
@@ -42,7 +42,8 @@ function Public.show_gui(event, game_name, message)
     title_flow.style.top_padding = 8
     title_flow.style.horizontally_stretchable = false
 
-    local title = title_flow.add {type = 'label', caption = 'Welcome to '..game_name}
+    local name = game_name:gsub('_', ' '):lower():gsub('(%l)(%w+)', function(a,b) return string.upper(a)..b end)
+    local title = title_flow.add {type = 'label', caption = 'Welcome to '..name}
     title.style.font = 'default-large-bold'
 
     --Body

--- a/modules/gui/mini_game_waiting.lua
+++ b/modules/gui/mini_game_waiting.lua
@@ -24,7 +24,8 @@ function Public.show_gui(event, game_name, current, required)
     title_flow.style.top_padding = 8
     title_flow.style.horizontally_stretchable = false
 
-    local title = title_flow.add {type = 'label', caption = 'Welcome to '..game_name}
+    local name = game_name:gsub('_', ' '):lower():gsub('(%l)(%w+)', function(a,b) return string.upper(a)..b end)
+    local title = title_flow.add {type = 'label', caption = 'Welcome to '..name}
     title.style.font = 'default-large-bold'
 
     --Body

--- a/modules/mini-games/Race.lua
+++ b/modules/mini-games/Race.lua
@@ -185,8 +185,9 @@ end
 local function on_player_joined(event)
     local player = game.players[event.player_index]
     local car = cars[player.name]
-    player.create_character()
-    player.teleport(car.position, car.surface)
+    local pos = car.surface.find_non_colliding_position('character', car.position, 6, 1)
+    local character = car.surface.create_entity{name='character', position=pos, force='player'}
+    player.set_controller{type = defines.controllers.character, character = character}
     car.set_driver(player)
 end
 

--- a/modules/mini-games/Race.lua
+++ b/modules/mini-games/Race.lua
@@ -89,6 +89,7 @@ race_count_down = Token.register(function()
         game.print("0 --> GO!", { 0, 1, 0 })
         for _, player in ipairs(Mini_games.get_participants()) do
             local car = cars[player.name]
+            if not car or not car.valid then return Mini_games.remove_participant(player) end
             car.get_fuel_inventory().insert{name = variables["fuel"], count = 100}
             scores[player.name].time = game.tick
         end
@@ -392,9 +393,10 @@ end
 
 --- Make the car and player destructible again
 local stop_invincibility = Token.register(function(name)
-    dead_cars[name].car.destructible = true
+    local car = dead_cars[name].car
+    if car and car.valid then car.destructible = true end
     local player = dead_cars[name].player
-    player.character.destructible = true
+    if player.character then player.character.destructible = true end
 end)
 
 --- Kill all biters in a close range to the player

--- a/modules/mini-games/admin_overide.lua
+++ b/modules/mini-games/admin_overide.lua
@@ -3,7 +3,8 @@ local Commands = require 'expcore.commands'
 
 Commands.new_command('stop', 'Command to stop a mini_game.')
 :register(function(_, _)
-    if Mini_games.get_current_game() then Mini_games.stop_game() end
+    local _, rtn = xpcall(Mini_games.stop_game, Commands.error)
+    return rtn
 end)
 
 Commands.new_command('start', 'Command to start a mini_game.')

--- a/modules/mini-games/space_race/scenario.lua
+++ b/modules/mini-games/space_race/scenario.lua
@@ -343,8 +343,6 @@ end
 local function stop()
     local won, player_names = primitives.won, {}
     for index, player in ipairs(game.connected_players) do
-        local gui = player.gui.center['Space-Race']
-        Gui.destroy_if_valid(gui)
         if player.force.name == won then
             player_names[index] = player.name
         end

--- a/modules/mini-games/space_race/scenario.lua
+++ b/modules/mini-games/space_race/scenario.lua
@@ -198,14 +198,15 @@ local function on_player_joined(event)
 
     if Mini_games.get_current_state() == 'Starting' then
         if player.character then player.character.destroy() end
-        player.create_character()
+        local pos = get_teleport_location(player.force, true)
+        local character = MS.get_surface().create_entity{name='character', position=pos, force=player.force}
+        player.set_controller{type = defines.controllers.character, character = character}
         game.permissions.get_group('Default').add_player(player)
         for _, item in pairs(starting_items) do
             player.insert(item)
         end
     end
 
-    player.teleport(get_teleport_location(player.force, true), MS.get_surface())
 end
 
 --- Tile map used to produce the two out of map walls

--- a/modules/mini-games/tightspot.lua
+++ b/modules/mini-games/tightspot.lua
@@ -301,6 +301,7 @@ local function on_player_joined(event)
     local player = game.players[event.player_index]
     local center = centers[player.name]
     player.teleport(center, variables.level.surface)
+    player.set_controller{ type = defines.controllers.god }
 
     -- Show the main gui for the game
     local Main_gui = Gui.get_left_element(player, game_gui)

--- a/modules/mini-games/tightspot.lua
+++ b/modules/mini-games/tightspot.lua
@@ -213,10 +213,13 @@ local function on_init(args)
 
     -- Setup all level related variables
     local level_index = tonumber(args[1])
-    variables.level = config[level_index]
-    variables.difficulty = variables.level.money[args[2]]
-    variables.loan_price = variables.level.loan_prices[args[2]]
-    variables["surface"] = game.surfaces[variables.level["surface"]]
+    local level = config[level_index]
+    if not level then return Mini_games.error_in_game('Level index out of range') end
+
+    variables.level = level
+    variables.difficulty = level.money[args[2]]
+    variables.loan_price = level.loan_prices[args[2]]
+    variables.surface = game.surfaces[level.surface]
 
     -- Save the island template
     if not save["tiles"][1] then level_save() end

--- a/modules/mini-games/tightspot.lua
+++ b/modules/mini-games/tightspot.lua
@@ -207,10 +207,6 @@ end
 
 --- Called before the game starts and before any players are added
 local function on_init(args)
-    variables["level"] = {}
-    variables["surface"] = {}
-    variables["walls"] = {}
-
     -- Setup all level related variables
     local level_index = tonumber(args[1])
     local level = config[level_index]
@@ -220,6 +216,7 @@ local function on_init(args)
     variables.difficulty = level.money[args[2]]
     variables.loan_price = level.loan_prices[args[2]]
     variables.surface = game.surfaces[level.surface]
+    variables["walls"] = {}
 
     -- Save the island template
     if not save["tiles"][1] then level_save() end
@@ -415,17 +412,19 @@ end
 --- The last function to be called, used to clean up variables
 local function on_close()
     -- Remove all placed entities
-    local area = variables.level.area
-    clean_up(area)
+    local level = variables.level
+    if level then clean_up(level.area) end
 
     -- Remake all entities from the template
-    for i, entity in ipairs(save.entities) do
-        local name = entity[1]
-        local position = entity[2]
-        local force = entity[3]
-        local minable = entity[4]
-        local ent = variables["surface"].create_entity {name = name, position = position, force = force}
-        ent.minable = minable
+    if save.entities then
+        for i, entity in ipairs(save.entities) do
+            local name = entity[1]
+            local position = entity[2]
+            local force = entity[3]
+            local minable = entity[4]
+            local ent = variables.surface.create_entity {name = name, position = position, force = force}
+            ent.minable = minable
+        end
     end
 
     -- Reset the global values


### PR DESCRIPTION
- See commit names for bugs which were fixed.
- Change on stop to only be called if the game was started, this means if the game was stopped during waiting or loading stage on stop will not be called and no stop game is wrote to file.
- Mini game participant selector is now called to be removed when a game stops removing the need to have it during on stop.