### PR TITLE
Fix error thrown from numeric usernames

### DIFF
--- a/utils/game.lua
+++ b/utils/game.lua
@@ -53,7 +53,8 @@ function Game.get_player_from_any(obj)
     if o_type == 'number' then
         p = Game.get_player_by_index(obj)
     elseif o_type == 'string' then
-        p = game.players[obj]
+        -- Usernames that are numbers above 2^16 may throw an error
+        pcall(function() p = game.players[obj] end)
     elseif o_type == 'table' and obj.valid and obj.is_player() then
         return obj
     end


### PR DESCRIPTION
Fix Game.get_player_from_any throwing an error on numeric user names that are not present in players array.  For some reason Factorio thinks they should be treated as the player index.

You should sanity check this, as I haven't tested it properly.