### PR TITLE
Speedrun uses time taken as score

### DIFF
--- a/config/mini_games/team_production.lua
+++ b/config/mini_games/team_production.lua
@@ -1,6 +1,6 @@
 return {
   ticks_to_generate_entities = 20,
-  time_before_round_end = 60*60*2,
+  time_before_round_end = 60*60*5,
   points_per_win = 20,
   distance_between_areas = 10,
 

--- a/expcore/Mini_games.lua
+++ b/expcore/Mini_games.lua
@@ -854,7 +854,7 @@ end
 local function Nth (n) return n..getSuffix(n) end
 
 --- Colours used while printing positions in chat
-local message_format = '%s: %s with %d %s'
+local message_format = '%s: %s with %s'
 local colors =  {
     ["1st"] = { 255, 215, 0   },
     ["2nd"] = { 192, 192, 192 },
@@ -862,16 +862,21 @@ local colors =  {
     default = { 128, 128, 128 }
 }
 
+local format_time = _C.format_time
 --- Print the results to game chat, follows the same requires as returning from on_close with optional names table as an override
-function Mini_games.print_results(results, unit, names, limit)
-    names = names or {}
-    limit = limit or 5
+function Mini_games.print_results(results, options)
+    local names = options.names or {}
+    local limit = options.limit or 5
     for i, result in ipairs(results) do
         if result.place < limit then
-            local place = Nth(result.place)
+            local place, score = Nth(result.place), result.score
             local colour = colors[place] or colors.default
             local name = names[i] or table.concat(result.players, ', ')
-            game.print(message_format:format(place, name, result.score, unit), colour)
+            if     options.time_seconds then score = format_time(score*60, options.time_seconds)
+            elseif options.time_ticks   then score = format_time(score, options.time_ticks)
+            elseif options.format       then score = options.format(score)
+            elseif options.unit         then score = score..' '..options.unit end
+            game.print(message_format:format(place, name, score), colour)
         end
     end
 end

--- a/modules/gui/player-list.lua
+++ b/modules/gui/player-list.lua
@@ -137,6 +137,9 @@ local player_list_container =
 Gui.element(function(event_trigger, parent)
     -- Draw the internal container
     local container = Gui.container(parent, event_trigger, 200)
+    local label = container.add{ type = 'label', name = 'no_players', caption = 'There are currently no players' }
+    label.style.horizontally_stretchable = true
+    label.style.padding = {2, 4}
 
     -- Draw the section for each force
     for name in pairs(game.forces) do
@@ -273,6 +276,7 @@ local function redraw_player_list()
     for _, player in pairs(game.connected_players) do
         local frame = Gui.get_left_element(player, player_list_container)
         local container = frame.container
+        container.no_players.visible = #player_list_order == 0
 
         for name in pairs(game.forces) do
             local scroll_table =  container[name] or section(container, name, 2).parent

--- a/modules/mini-games/Race.lua
+++ b/modules/mini-games/Race.lua
@@ -242,6 +242,7 @@ end
 --- Get the position number with the suffix appended
 local function Nth (n) return n..getSuffix(n) end
 
+local result_options = { time_seconds = {minutes = true, seconds = true, long = true, string = true} }
 --- Function called by mini game module to stop a race
 local function stop()
     -- Print the place that each player came
@@ -263,7 +264,7 @@ local function stop()
 
     end
 
-    Mini_games.print_results(results, 'seconds')
+    Mini_games.print_results(results, result_options)
     return results
 end
 

--- a/modules/mini-games/speedrun.lua
+++ b/modules/mini-games/speedrun.lua
@@ -272,8 +272,11 @@ local function update_progress(force, data)
     -- Check if the team has finished
     if data[1] == data[2] then
         local names, last = {}, #scores + 1
-        for index, player in ipairs(forces[name].players) do names[index] = player.name end
         local time = math.floor((game.tick - Mini_games.get_start_time())/60)
+        for index, player in ipairs(forces[name].players) do
+            Mini_games.remove_participant(player)
+            names[index] = player.name
+        end
         scores[last] = { name, time, names }
         -- Check if all teams are done
         if last == primitives.team_count then Mini_games.stop_game() end

--- a/modules/mini-games/speedrun.lua
+++ b/modules/mini-games/speedrun.lua
@@ -167,6 +167,7 @@ end
 
 ----- Game Stop and Close -----
 
+local result_time_options = { hours = true, minutes = true, seconds = true, long = true, string = true }
 --- Called to stop the game and return the results to be saved
 local function stop()
 
@@ -189,7 +190,7 @@ local function stop()
         end
     end
 
-    Mini_games.print_results(results, 'percent', names)
+    Mini_games.print_results(results, { time_seconds = result_time_options, names = names })
     return results
 end
 
@@ -276,7 +277,7 @@ local function update_progress(force, data)
         scores[last] = { name, time, names }
         -- Check if all teams are done
         if last == primitives.team_count then Mini_games.stop_game() end
-end
+    end
 end
 
 --- Checks if an indicator has already been used
@@ -384,11 +385,11 @@ local function check_item_production()
 end
 
 --- Ran every tick to update the timer
-local options = { hours = true, minutes = true, seconds = true, milliseconds = true, time = true, div = 'time-format.simple-format-div-space' }
 local format_time = _C.format_time
+local timer_options = { hours = true, minutes = true, seconds = true, milliseconds = true, time = true, div = 'time-format.simple-format-div-space' }
 local function on_tick()
     local time = game.tick - Mini_games.get_start_time()
-    local format = format_time(time, options)
+    local format = format_time(time, timer_options)
     for _, player in ipairs(game.connected_players) do
         local container = Gui.get_left_element(player, timer_container)
         container.timer.caption = format

--- a/modules/mini-games/team_production/team_production.lua
+++ b/modules/mini-games/team_production/team_production.lua
@@ -615,7 +615,7 @@ local function stop()
       end
   end
 
-  Mini_games.print_results(results, 'points', names)
+  Mini_games.print_results(results, { unit = 'points', names = names })
   return results
 end
 

--- a/modules/mini-games/tightspot.lua
+++ b/modules/mini-games/tightspot.lua
@@ -345,6 +345,7 @@ end
 --- When a player is removed hide the gui
 local on_player_removed = on_player_left
 
+local result_options = { unit = 'points' }
 --- Function called by mini game module to stop this game
 local function stop()
     game.speed = 1
@@ -380,7 +381,7 @@ local function stop()
 
     end
 
-    Mini_games.print_results(results, 'points')
+    Mini_games.print_results(results, result_options)
     return results
 end
 


### PR DESCRIPTION
- Speed run will now use the time taken as the score for the team #42
- Printed results for both speed run and race are formatted better; ie minutes and seconds rather than just seconds
- Delay at the end of team production has been increased to 5 minutes (from 2)
- At the end of speed run you are moved to spectator so you can watch other teams
- Player list will show a message when there are no players to avoid the in-complete look