### PR TITLE
Add Variant data for Race

### DIFF
--- a/expcore/Mini_games.lua
+++ b/expcore/Mini_games.lua
@@ -557,9 +557,13 @@ local start_game = Token.register(function(timeout_nonce)
 
     -- Calls on_start core event to start the game
     local on_start = mini_game.core_events.on_start
+    local start_data = {}
     if on_start then
         dlog('Call: On Start')
-        xpcall(on_start, internal_error)
+        local status, result = xpcall(on_start, internal_error)
+        if status and result then
+            start_data = result
+        end
     end
 
     -- Write the game start to file
@@ -567,6 +571,7 @@ local start_game = Token.register(function(timeout_nonce)
         type      = 'started_game',
         players   = Mini_games.get_participant_names(),
         name      = mini_game.name,
+        variant   = start_data.variant,
     }
 
     dlog('Start:', mini_game.name, 'Player Count:', #data.players)

--- a/modules/mini-games/Race.lua
+++ b/modules/mini-games/Race.lua
@@ -207,6 +207,14 @@ local function start()
     game.print("Racing in a car with "..variables["fuel"], colour)
     game.print("Laps: "..variables["laps"], colour)
     task.set_timeout_in_ticks(10, race_count_down)
+
+    return {
+        variant = table.concat({
+            variables["config"].name,
+            variables["laps"] .. " Laps",
+            variables["fuel"],
+        }, " | "),
+    }
 end
 
 ----- Game Cleanup -----


### PR DESCRIPTION
Tell which map, how many laps and the fuel type used to the backend via
the started_game event by passing this info back from the on_start event
to the mini-game.