### PR TITLE
Feature/extra score data

### DIFF
--- a/expcore/Mini_games.lua
+++ b/expcore/Mini_games.lua
@@ -871,7 +871,7 @@ function Mini_games.print_results(results, unit, names, limit)
     names = names or {}
     limit = limit or 5
     for i, result in ipairs(results) do
-        if result.place < limit then
+        if result.place and result.place < limit then
             local place = Nth(result.place)
             local colour = colors[place] or colors.default
             local name = names[i] or table.concat(result.players, ', ')

--- a/expcore/Mini_games.lua
+++ b/expcore/Mini_games.lua
@@ -572,6 +572,7 @@ local start_game = Token.register(function(timeout_nonce)
         players   = Mini_games.get_participant_names(),
         name      = mini_game.name,
         variant   = start_data.variant,
+        extra     = start_data.extra,
     }
 
     dlog('Start:', mini_game.name, 'Player Count:', #data.players)

--- a/expcore/Mini_games.lua
+++ b/expcore/Mini_games.lua
@@ -873,7 +873,7 @@ function Mini_games.print_results(results, options)
     local names = options.names or {}
     local limit = options.limit or 5
     for i, result in ipairs(results) do
-        if result.place and result.place < limit then
+        if result.place and result.place < limit and result.score then
             local place, score = Nth(result.place), result.score
             local colour = colors[place] or colors.default
             local name = names[i] or table.concat(result.players, ', ')

--- a/modules/mini-games/Race.lua
+++ b/modules/mini-games/Race.lua
@@ -214,6 +214,11 @@ local function start()
             variables["laps"] .. " Laps",
             variables["fuel"],
         }, " | "),
+        extra = {
+            name = variables["config"].name,
+            laps = variables["laps"],
+            fuel = variables["fuel"],
+        }
     }
 end
 

--- a/modules/mini-games/Race.lua
+++ b/modules/mini-games/Race.lua
@@ -184,7 +184,7 @@ local function on_player_added(event)
     }
 
     cars[name] = car
-    scores[name] = {}
+    scores[name] = { cars_wrecked = 0 }
     car.operable = false
     player_progress[name] = 1
 end
@@ -288,11 +288,10 @@ local function stop()
             results_by_name[name] = results[#results]
         end
 
-        if score.laps then
-            results_by_name[name].extra = {
-                laps = score.laps,
-            }
-        end
+        results_by_name[name].extra = {
+            laps = score.laps,
+            cars_wrecked = score.cars_wrecked,
+        }
     end
 
     -- Print the place that each player came
@@ -493,6 +492,8 @@ local car_destroyed = function(event)
     task.set_timeout_in_ticks(190+offset, kill_biters, name)
     task.set_timeout_in_ticks(480+offset, stop_invincibility, name)
 
+    -- Increment cars wrecked counter
+    scores[name].cars_wrecked = scores[name].cars_wrecked + 1
 end
 
 --- Triggered when a player enters or leaves a car, used to keep them in the car

--- a/modules/mini-games/Race.lua
+++ b/modules/mini-games/Race.lua
@@ -270,18 +270,20 @@ local function stop()
     local results_by_name = {}
 
     -- Add scores for players that finished the game
+    local last = 0
     for name, result in pairs(variables["finish_times"]) do
-        results[#results + 1] = {
+        local curr = {
             place = result.place,
             score = math.round(result.time, 2),
             players = {name}
         }
-        results_by_name[name] = results[#results]
+        last = last + 1
+        results[last] = curr
+        results_by_name[name] = curr
 
         -- Correct placement in case of score ties
-        if #results > 1 then
-            local prev = results[#results - 1]
-            local curr = results[#results]
+        if last > 1 then
+            local prev = results[last - 1]
             if curr.score == prev.score then
                 curr.place = prev.place
             end


### PR DESCRIPTION
Restructure the results entries returned by the on_stop event for the Race game to include laps and cars wrecked.  Due to time constraints I've not implemented the same for the other mini-games yet but the previous format is compatible with the new one.  The new format of the results entries is

```lua
local results = {
    { place = 1, players = { "winner" }, score = 123, extra = { description = "Anything JSON serializable to add to the entry" } },
    { place = 2, players = { "second" }, score = 23, extra = { progress = 93, fun = true } },
    -- ties are represented by giving the same place to multiple entries
    { place = 2, players = { "tied" }, score = 23, extra = { progress = 58 } },
    -- place and score is optional, which allows for adding data to players that did not finish.
    { players = { "slowpoke" }, extra = { progress = 12, fun = false } },
}
```

I also added a machine readable version of the variant to match records.

Implementation of #32.