### PR TITLE
Unstuck car implementation

### DIFF
--- a/config/expcore/roles.lua
+++ b/config/expcore/roles.lua
@@ -108,6 +108,7 @@ local default = Roles.new_role('Guest','')
     'command/warp',
     'command/join-UFE',
     'command/join-UFW',
+    'command/unstuck',
     'command/lobby',
 }
 

--- a/expcore/Mini_games.lua
+++ b/expcore/Mini_games.lua
@@ -820,7 +820,7 @@ function Mini_games.stop_game()
 
     -- Disable all commands for this mini game
     for _, command_name  in ipairs(mini_game.commands) do
-        Commands.enable(command_name)
+        Commands.disable(command_name)
     end
 
     if skip_timeout then

--- a/modules/mini-games/Race.lua
+++ b/modules/mini-games/Race.lua
@@ -417,7 +417,7 @@ end)
 local respawn_car
 respawn_car = Token.register(function(name)
     local player = dead_cars[name].player
-    local position = surface[1].find_non_colliding_position('car', dead_cars[name].position, 5, 0.5)
+    local position = surface[1].find_non_colliding_position('assembling-machine-1', dead_cars[name].position, 5, 0.5)
     if not position then
         return task.set_timeout_in_ticks(30, respawn_car, name)
     end

--- a/modules/mini-games/Race.lua
+++ b/modules/mini-games/Race.lua
@@ -419,8 +419,7 @@ Commands.new_command('unstuck', 'Unstuck your car from walls')
 :register(function(player)
     local car = cars[player.name]
     if not car or not car.valid then
-        player.print("Not in a car!")
-        return Commands.error
+        return Commands.error("Not in a car.")
     end
 
     local new_position = surface[1].find_non_colliding_position('assembling-machine-1', car.position, 5, 0.5)

--- a/modules/mini-games/Race.lua
+++ b/modules/mini-games/Race.lua
@@ -5,6 +5,7 @@ local Permission_Groups = require "expcore.permission_groups"
 local Global            = require 'utils.global' --Used to prevent desyncing.
 local interface         = require 'modules.commands.interface'
 local Gui               = require 'expcore.gui._require'
+local Commands          = require 'expcore.commands'
 local config = require "config.mini_games.Race"
 
 local surface = {}
@@ -413,6 +414,19 @@ local kill_biters = Token.register(function(name)
     end
 end)
 
+--- Unstuck yourself
+Commands.new_command('unstuck', 'Unstuck your car from walls')
+:register(function(player)
+    local car = cars[player.name]
+    if not car or not car.valid then
+        player.print("Not in a car!")
+        return Commands.error
+    end
+
+    local new_position = surface[1].find_non_colliding_position('assembling-machine-1', car.position, 5, 0.5)
+    car.teleport(new_position, surface[1])
+end)
+
 --- Respawn the car for a player
 local respawn_car
 respawn_car = Token.register(function(name)
@@ -558,3 +572,5 @@ race:add_event(Mini_games.events.on_participant_added, on_player_added)
 race:add_event(Mini_games.events.on_participant_created, on_player_created)
 race:add_event(Mini_games.events.on_participant_left, on_player_left)
 race:add_event(Mini_games.events.on_participant_removed, on_player_removed)
+
+race:add_command('unstuck')


### PR DESCRIPTION
Change to using an assembly machine as the name for the find_non_colliding_possition call.  This will make it use a larger bounding box for checking collisions and thereby place the car some distance away from the wall.

Implement /unstuck command as detailed in #51.  No GUI since I'm not sure how to do that properly.  The command might be a bit abusable as it generally places you some distance away from your current position, so if you collide into an obstacle and use it you get put left or right from your current position and could probably start driving immediately.  Same goes for escaping a biter swarm with it.