### PR TITLE
Fixed chart sharing on team games

### DIFF
--- a/modules/mini-games/space_race/scenario.lua
+++ b/modules/mini-games/space_race/scenario.lua
@@ -73,17 +73,24 @@ local function on_init(args)
     local force_USA = game.create_force(args[2] or 'United Factory Workers')
     local force_USSR = game.create_force(args[3] or 'Union of Factory Employees')
 
-    local surface = MS.generate_surface('Space_Race')
-    surface.min_brightness = 0;
+    local force_player = game.forces.player
+    force_USA.set_friend(force_player, true)
+    force_USSR.set_friend(force_player, true)
 
-    force_USSR.set_spawn_position({x = 409, y = 0}, surface)
-    force_USA.set_spawn_position({x = -409, y = 0}, surface)
+    force_USA.share_chart = true
+    force_USSR.share_chart = true
 
     force_USSR.laboratory_speed_modifier = 1
     force_USA.laboratory_speed_modifier = 1
 
     force_USSR.research_queue_enabled = true
     force_USA.research_queue_enabled = true
+
+    local surface = MS.generate_surface('Space_Race')
+    surface.min_brightness = 0
+
+    force_USSR.set_spawn_position({x = 409, y = 0}, surface)
+    force_USA.set_spawn_position({x = -409, y = 0}, surface)
 
     surface.request_to_generate_chunks({400, 0}, 3)
     surface.request_to_generate_chunks({-400, 0}, 3)

--- a/modules/mini-games/speedrun.lua
+++ b/modules/mini-games/speedrun.lua
@@ -120,11 +120,14 @@ local function init(args)
     if not map_seed or map_seed < 0 or map_seed > 4294967295 then Mini_games.error_in_game('Map seed is invalid') end
 
     -- Create a surface for each team with the same seed and settings
-    local remaining, indicators = { seed = map_seed }, goals[target]
+    local remaining, indicators, force_player = { seed = map_seed }, goals[target], game.forces.player
     for i = 1, team_count do
         local name = 'Team '..i
+        local force = game.create_force(name)
+        force.set_friend(force_player, true)
+        force.share_chart = true
+        forces[name] = force
         remaining[i] = name
-        forces[name] = game.create_force(name)
         progress[name] = { 0, indicators.total, table.deep_copy(indicators) }
     end
 


### PR DESCRIPTION
During speedrun and CnC the spectators are unable to see anything on the map. This is because when in spectator you do not cause chunks to be generated or charted. To fix #65 I used LuaForce.share_chart and set the force to be friends with the player force (where the spectators are) this allows the spectators to view all teams on the map.