### PR TITLE
Fixes for player follow

### DIFF
--- a/modules/control/follow.lua
+++ b/modules/control/follow.lua
@@ -79,11 +79,9 @@ end)
 -- @tparam LuaPlayer player The player to update the position of
 -- @tparam ?LuaPlayer|LuaEntity entity The player or entity being followed
 local function update_player_location(player, entity, old_position)
-    if not player.connected or player.character then
+    if player.character or not entity.valid then
         Public.stop(player)
     elseif player.position.x ~= old_position.x or player.position.y ~= old_position.y then
-        Public.stop(player)
-    elseif not entity.valid then
         Public.stop(player)
     else
         player.teleport(entity.position)
@@ -100,6 +98,17 @@ end
 
 -- Update the location of all players each tick
 Event.add(defines.events.on_tick, update_all)
+
+-- Check for player leaving
+Event.add(defines.events.on_player_left_game, function(event)
+    local player = game.players[event.player_index]
+    Public.stop(player)
+    for _, data in pairs(following) do
+        if data[2] == player then
+            Public.stop(data[1])
+        end
+    end
+end)
 
 ----- Module Return -----
 return Public

--- a/modules/control/follow.lua
+++ b/modules/control/follow.lua
@@ -12,11 +12,45 @@ Global.register(following, function(tbl)
     following = tbl
 end)
 
+----- Public Functions -----
+
+local follow_label
+--- Used to start a player following an entity or player
+-- @tparam LuaPlayer player The player that will follow the entity
+-- @tparam ?LuaPlayer|LuaEntity entity The player or entity that will be followed
+function Public.start(player, entity)
+    assert(player and player.valid, 'Invalid player given to follower')
+    assert(entity and entity.valid, 'Invalid entity given to follower')
+    -- Due to current use case we do not need to handle player characters, however using associate_character it would be possible
+    assert(not player.character, 'Player can not have a character while following another')
+
+    player.close_map()
+    follow_label(player.gui.screen, entity)
+    player.teleport(entity.position, entity.surface)
+    following[player.index] = {player, entity, entity.position}
+end
+
+--- Used to stop a player following an entity or player
+-- @tparam LuaPlayer player The player that you want to stop following their entity
+function Public.stop(player)
+    assert(player and player.valid, 'Invalid player given to follower')
+
+    Gui.destroy_if_valid(player.gui.screen[follow_label.name])
+    following[player.index] = nil
+end
+
+--- Used to stop all players following an entity or player
+function Public.stop_all()
+    for key in pairs(following) do
+        following[key] = nil
+    end
+end
+
 ----- Gui -----
 
 --- Label used to show that the player is following, also used to allow esc to stop following
 -- @element follow_label
-local follow_label =
+follow_label =
 Gui.element(function(event_trigger, parent, target)
     Gui.destroy_if_valid(parent[event_trigger])
 
@@ -39,46 +73,15 @@ end)
 :on_closed(Public.stop)
 :on_click(Public.stop)
 
------ Public Functions -----
-
---- Used to start a player following an entity or player
--- @tparam LuaPlayer player The player that will follow the entity
--- @tparam ?LuaPlayer|LuaEntity entity The player or entity that will be followed
-function Public.start(player, entity)
-    assert(player and player.valid, 'Invalid player given to follower')
-    assert(entity and entity.valid, 'Invalid entity given to follower')
-    -- Due to current use case we do not need to handle player characters, however using associate_character it would be possible
-    assert(not player.character, 'Player can not have a character while following another')
-
-    player.close_map()
-    follow_label(player.gui.screen, entity)
-    player.teleport(entity.position, entity.surface)
-    following[player.index] = {player, entity}
-end
-
---- Used to stop a player following an entity or player
--- @tparam LuaPlayer player The player that you want to stop following their entity
-function Public.stop(player)
-    assert(player and player.valid, 'Invalid player given to follower')
-
-    Gui.destroy_if_valid(player.gui.screen[follow_label.name])
-    following[player.index] = nil
-end
-
---- Used to stop all players following an entity or player
-function Public.stop_all()
-    for key in pairs(following) do
-        following[key] = nil
-    end
-end
-
 ----- Events -----
 
 --- Updates the location of the player as well as doing some sanity checks
 -- @tparam LuaPlayer player The player to update the position of
 -- @tparam ?LuaPlayer|LuaEntity entity The player or entity being followed
-local function update_player_location(player, entity)
+local function update_player_location(player, entity, old_position)
     if not player.connected or player.character then
+        Public.stop(player)
+    elseif player.position.x ~= old_position.x or player.position.y ~= old_position.y then
         Public.stop(player)
     elseif not entity.valid then
         Public.stop(player)
@@ -90,7 +93,8 @@ end
 --- Updates the locations of all players currently following something
 local function update_all()
     for _, data in pairs(following) do
-        update_player_location(data[1], data[2])
+        update_player_location(data[1], data[2], data[3])
+        data[3] = data[1].position
     end
 end
 

--- a/modules/control/follow.lua
+++ b/modules/control/follow.lua
@@ -22,6 +22,7 @@ function Public.start(player, entity)
     -- Due to current use case we do not need to handle player characters, however using associate_character it would be possible
     assert(not player.character, 'Player can not have a character while following another')
 
+    player.close_map()
     player.teleport(entity.position, entity.surface)
     following[player.index] = {player, entity}
 end

--- a/modules/gui/player-list.lua
+++ b/modules/gui/player-list.lua
@@ -48,7 +48,7 @@ end)
         if player.character then
             player.zoom_to_world(selected_player.position, 1.75)
         else
-            Follow.start(player.gui.screen, selected_player)
+            Follow.start(player, selected_player)
         end
     end
 end)

--- a/modules/gui/player-list.lua
+++ b/modules/gui/player-list.lua
@@ -13,36 +13,6 @@ local Colors = require 'utils.color_presets' --- @dep utils.color_presets
 local Follow = require 'modules.control.follow'--- @dep modules.control.follow
 local format_time = _C.format_time --- @dep expcore.common
 
---- Label used to show that the player is following, also used to allow esc to stop following
--- @element follow_label
-local follow_label =
-Gui.element(function(event_trigger, parent, following)
-    local label = parent.add{
-        name = event_trigger,
-        type = 'label',
-        style = 'heading_1_label',
-        caption = 'Following '..following.name..'.\nPress ESC or this text to stop.'
-    }
-
-    local player = Gui.get_player_from_element(parent)
-    local res = player.display_resolution
-    label.location = {0, res.height-150}
-    label.style.width = res.width
-    label.style.horizontal_align = 'center'
-    player.opened = label
-
-    Follow.start(player, following)
-    return label
-end)
-:on_closed(function(player, element)
-    Follow.stop(player)
-    Gui.destroy_if_valid(element)
-end)
-:on_click(function(player, element)
-    Follow.stop(player)
-    Gui.destroy_if_valid(element)
-end)
-
 --- Set of elements that are used to make up a row of the player table
 -- @element add_player_base
 local add_player_base =
@@ -78,7 +48,7 @@ end)
         if player.character then
             player.zoom_to_world(selected_player.position, 1.75)
         else
-            follow_label(player.gui.screen, selected_player)
+            Follow.start(player.gui.screen, selected_player)
         end
     end
 end)


### PR DESCRIPTION
- When follow starts the player map will be closed
- When clicking a second player the label will correctly update and you will follow the new player
- When you leave the game your label is removed, and anyone who was following you stops following you
- When you move while following someone you will not stop following them

Fixes #72 